### PR TITLE
Use Random instead of SecureRandom to work around the blocking caused…

### DIFF
--- a/stepengine/src/main/java/org/tweetwallfx/devoxx18be/steps/mosaic/ImageMosaicAnimateImageStep.java
+++ b/stepengine/src/main/java/org/tweetwallfx/devoxx18be/steps/mosaic/ImageMosaicAnimateImageStep.java
@@ -23,7 +23,6 @@
  */
 package org.tweetwallfx.devoxx18be.steps.mosaic;
 
-import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
@@ -52,7 +51,7 @@ public class ImageMosaicAnimateImageStep implements Step {
         // prevent external instantiation
     }
 
-    private static final Random RANDOM = new SecureRandom();
+    private static final Random RANDOM = new Random();
 
     private final Set<Integer> highlightedIndexes = new HashSet<>();
 

--- a/stepengine/src/main/java/org/tweetwallfx/devoxx18be/steps/mosaic/ImageMosaicCreateStep.java
+++ b/stepengine/src/main/java/org/tweetwallfx/devoxx18be/steps/mosaic/ImageMosaicCreateStep.java
@@ -23,7 +23,6 @@
  */
 package org.tweetwallfx.devoxx18be.steps.mosaic;
 
-import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,7 +51,7 @@ import org.tweetwallfx.stepengine.dataproviders.ImageMosaicDataProvider.ImageSto
 public class ImageMosaicCreateStep implements Step {
 
     private final Config config;
-    private static final Random RANDOM = new SecureRandom();
+    private static final Random RANDOM = new Random();
     private ImageView[][] rects;
     private Bounds[][] bounds;
     private Pane pane;


### PR DESCRIPTION
… by missing entropy. Fixes #44.